### PR TITLE
Add POST to MarkdownRegistry & support in Get()

### DIFF
--- a/src/BabelMark/ApiController.cs
+++ b/src/BabelMark/ApiController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -136,6 +137,10 @@ namespace BabelMark
                         {
                             ["html"] = await responseMessage.Content.ReadAsStringAsync()
                         };
+
+                        if (!string.IsNullOrWhiteSpace(implem.VersionHeader)) {
+                            jobject["version"] = responseMessage.Headers.GetValues(implem.VersionHeader).FirstOrDefault();
+                        }
                     }
                     else
                     {

--- a/src/BabelMark/MarkdownRegistry.cs
+++ b/src/BabelMark/MarkdownRegistry.cs
@@ -20,6 +20,8 @@ namespace BabelMark
         public bool CommonMark { get; set; }
 
         public bool POST { get; set; }
+
+        public string VersionHeader { get; set; }
     }
 
     public class MarkdownRegistry

--- a/src/BabelMark/MarkdownRegistry.cs
+++ b/src/BabelMark/MarkdownRegistry.cs
@@ -18,6 +18,8 @@ namespace BabelMark
         public string Repo { get; set; }
 
         public bool CommonMark { get; set; }
+
+        public bool POST { get; set; }
     }
 
     public class MarkdownRegistry


### PR DESCRIPTION
This adds support for `POST`ing a `text/plain` body to an endpoint. See https://github.com/github/cmark/issues/67#issuecomment-345581687 for motivation.

The registry pull is at babelmark/babelmark-registry#5.

/cc @xoofx 